### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,9 @@
 
 name: Python package
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/shanegladson/PyMCGE/security/code-scanning/1](https://github.com/shanegladson/PyMCGE/security/code-scanning/1)

In general, this issue is fixed by explicitly defining a `permissions` block in the workflow (either at the top level or per job) to restrict the GITHUB_TOKEN to the minimal scopes needed. For a typical Python CI workflow that only checks out code and runs tests, `contents: read` is usually sufficient, as no write operations to the repo or other resources are performed.

For this specific workflow in `.github/workflows/python-package.yml`, the best fix without changing existing functionality is to add a root-level `permissions` block right after the `name: Python package` line. This block should grant read-only access to repository contents, which is enough for `actions/checkout` and reading the code under test. No additional scopes (like `pull-requests` or `issues`) appear necessary based on the shown steps. The change is limited to adding:

```yaml
permissions:
  contents: read
```

around line 5–6, before the `on:` trigger definition. No imports or additional methods are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
